### PR TITLE
In cmdfs_read(), use pread(), not lseek()

### DIFF
--- a/src/cmdfs.c
+++ b/src/cmdfs.c
@@ -189,8 +189,7 @@ int cmdfs_readlink(const char *path, char *buf, size_t size) {
 int cmdfs_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *info) {
 	vfile_t *f = (vfile_t *)(long)info->fh;
 	if ( f ) {
-		lseek(file_get_handle(f),offset,SEEK_SET);
-		return read(file_get_handle(f), buf, size);
+		return pread(file_get_handle(f), buf, size, offset);
 	}
 	else
 		return -EIO;


### PR DESCRIPTION
There is nothing stopping a user from making multiple simultaneous `read()` calls from multiple threads to the *same* file. cmdfs does not handle that well, because that makes the `lseek()` and `read()` calls race
against each other. Here's an example strace output showing the problem:

    read[139820714169600] 131072 bytes from 23134208 flags: 0x8000
    [pid 29077] read(6,  <unfinished ...>
    [pid 29059] lseek(6, 23134208, SEEK_SET <unfinished ...>
    [pid 29077] <... read resumed> "]~'\244Ual`\322\222\263NQD4\341\335\343\320\232\35C58\254o\272\311\23P\341P"..., 131072) = 131072
    [pid 29059] <... lseek resumed> )       = 23134208
       read[139820714169600] 131072 bytes from 23003136
       unique: 183, success, outsize: 131088

This is actually quite a big problem, because such simultaneous calls are quite commonplace in practice (it's how readahead is typically done). The result is gross corruption of read data, which is quite obvious and fairly easy to reproduce (even something as simple as running `sha1sum` twice in a row will give a different result).

This commit solves the problem by replacing the `lseek()` and `read()` calls by a single `pread()` call, which is specifically designed to solve that problem.