### PR TITLE
Fix a directory handle leak in the cleaner routine

### DIFF
--- a/src/cleaner.c
+++ b/src/cleaner.c
@@ -98,6 +98,7 @@ void *cleaner_run( void *_cleaner ) {
 						}
 					}
 				}
+				closedir(dirp);
 				if ( 	(c->size_lim > 0 && dirsize > c->size_lim) ||
 						(c->entry_lim > 0 && entries_count > c->entry_lim) ) {
 					// Directory is over size limit or entry limit, sort by access time ready to cull


### PR DESCRIPTION
This had the effect of leaking one file descriptor per second. It only takes about 17 minutes before things start failing as the process runs into the typical 1024 max file descriptors limit.